### PR TITLE
IW | Inherit modal z-index for now

### DIFF
--- a/src/themes/fandom/windows.less
+++ b/src/themes/fandom/windows.less
@@ -322,6 +322,7 @@
 	&-modal > .oo-ui-dialog {
 		background-color: @dialog-overlay-background-color;
 		opacity: 0;
+		z-index: inherit;
 		.oo-ui-transition(opacity @transition-base);
 
 		> .oo-ui-window-frame {


### PR DESCRIPTION
Currently, the z-index for OOUI dialogs is hardcoded to 4.
Let's set it to inherit for now to allow skins to specify a custom
z-index as needed by setting it on the windowManager element.