### PR TITLE
IW-2923 | VE: Implement toolbar styling improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fandom/oojs-ui",
-  "version": "0.35.1-paddings2",
+  "version": "0.35.1-ve1",
   "description": "User interface classes built on the OOjs framework.",
   "keywords": [
     "oojs-plugin",

--- a/src/themes/fandom/icons-editing-styling.json
+++ b/src/themes/fandom/icons-editing-styling.json
@@ -28,7 +28,7 @@
 					"ar": "../wikimediaui/images/icons/bold-arab-ain.svg",
 					"be": "../wikimediaui/images/icons/bold-cyrl-te.svg",
 					"ce": "../wikimediaui/images/icons/bold-cyrl-palochka.svg",
-					"cs,en,he,ml,pl,sco": "../wikimediaui/images/icons/bold-b.svg",
+					"cs,en,he,ml,pl,sco": "~design-system-svg/wds-icons-bold-small.svg",
 					"da,de,hu,ksh,nn,no,sv": "../wikimediaui/images/icons/bold-f.svg",
 					"es,gl,pt": "../wikimediaui/images/icons/bold-n.svg",
 					"eu,fi": "../wikimediaui/images/icons/bold-l.svg",
@@ -51,7 +51,7 @@
 				"default": "../wikimediaui/images/icons/italic-a.svg",
 				"lang": {
 					"ar": "../wikimediaui/images/icons/italic-arab-meem.svg",
-					"cs,en,fr,he,ml,pl,pt,sco": "../wikimediaui/images/icons/italic-i.svg",
+					"cs,en,fr,he,ml,pl,pt,sco": "~design-system-svg/wds-icons-italics-small.svg",
 					"be,ce,da,de,fi,ky,nn,no,os,sv,ru,uk": "../wikimediaui/images/icons/italic-k.svg",
 					"es,gl,it,nl": "../wikimediaui/images/icons/italic-c.svg",
 					"eu": "../wikimediaui/images/icons/italic-e.svg",
@@ -95,6 +95,9 @@
 		},
 		"textFormat": {
 			"file": "~design-system-svg/wds-icons-text-small.svg"
+		},
+		"paragraph": {
+			"file": "~design-system-svg/wds-icons-paragraph-small.svg"
 		}
 	}
 }

--- a/src/themes/fandom/tools.less
+++ b/src/themes/fandom/tools.less
@@ -76,7 +76,11 @@
 }
 
 .theme-oo-ui-toolGroup() {
-	padding: 0 12px;
+	padding: 0 6px;
+
+	&:first-child {
+		padding-left: 0;
+	}
 
 	&:not(:last-child) {
 		border-right-style: @border-style-base;


### PR DESCRIPTION
* Use DS icons for bold and italic icons as appropriate for the language
* Reduce horizontal padding of toolbar tool groups to make toolbar more compact
* Remove extraneous left padding of the first tool group in toolbars
* Add DS paragraph icon, for use in toolbars