### PR TITLE
Remove overly broad FieldLayout header styles

### DIFF
--- a/src/themes/fandom/layouts.less
+++ b/src/themes/fandom/layouts.less
@@ -67,10 +67,7 @@
 
 	&.oo-ui-labelElement {
 		> .oo-ui-fieldLayout-body > .oo-ui-fieldLayout-header {
-			font-size: @wds-font-size-xxs;
-			font-weight: @wds-font-weight-bold;
 			padding-bottom: @padding-vertical-label;
-			text-transform: uppercase;
 		}
 
 		&.oo-ui-fieldLayout-align-top > .oo-ui-fieldLayout-body > .oo-ui-fieldLayout-header,


### PR DESCRIPTION
In 740ab03b8b690a7118f4ea1980f395a26292cf32, we applied some general font styling to FieldLayout headers. This is too broad, and should instead be applied only to the particular FieldLayout that needs it. Remove the styles accordingly.