### PR TITLE
IW-4252 | Change articleSearch and highlight icons

### DIFF
--- a/src/themes/fandom/icons-content.json
+++ b/src/themes/fandom/icons-content.json
@@ -31,7 +31,7 @@
 			}
 		},
 		"articleSearch": {
-			"file": "../wikimediaui/images/icons/articleSearch.svg"
+			"file": "~design-system-svg/wds-icons-magnifying-glass-small.svg"
 		},
 		"articleRedirect": {
 			"file": {

--- a/src/themes/fandom/icons-editing-styling.json
+++ b/src/themes/fandom/icons-editing-styling.json
@@ -44,7 +44,7 @@
 			}
 		},
 		"highlight": {
-			"file": "~design-system-svg/wds-icons-pencil-small.svg"
+			"file": "../wikimediaui/images/icons/highlight.svg"
 		},
 		"italic": {
 			"file": {


### PR DESCRIPTION
Use our WDS search icon for articleSearch, and return to the original
wikimediaui icon for highlight.