### PR TITLE
CATS-793 | Ensure OOUI dialogs don't overlap with static site elements

### DIFF
--- a/src/themes/fandom/windows.less
+++ b/src/themes/fandom/windows.less
@@ -326,7 +326,8 @@
 	&-modal&-floating > .oo-ui-dialog > .oo-ui-window-frame {
 		border-radius: @border-radius-base;
 		bottom: 1em;
-		max-height: e('calc( 100% - 2em )');
+		// Ensure dialogs don't overlap with static site elements such as the global nav
+		max-height: e('calc( 100% - 8em )');
 		top: 1em;
 	}
 }


### PR DESCRIPTION
Currently, the OOUI dialogs using the Fandom theme use the same height
calculation logic as the default themes, which are designed with Vector and
derivatives in mind. This poses a problem on Oasis, where the dialogs may end up
overlapping with (and thus obscured by) static site elements such as the global
nav.

As a fix, reduce the maximum allowed height for these dialogs ever so slightly
to ensure they steer clear of those elements.